### PR TITLE
Integration corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,14 @@ This module relies on the following being true to keep things as simple as possi
 
 - All Snowflake objects exist/are created under the same database and schema: the tables,
   file format, stages and pipes
+- The following are created on top of this module (not an extensive list):
+  - Tables
+  - File Format
+  - `aws_ssm_parameter.snowflake_external_account_arn`
+  - `aws_ssm_parameter.snowflake_external_id`
+  - Other permissions
 - All files share the same file format
-- All copy statements are defined as a simple
+- The default copy statements are defined as a simple
   ```sql
   COPY INTO [DATABASE].[SCHEMA].[TABLE_NAME]
   FROM @[DATABASE].[SCHEMA].STAGE_[TABLE_NAME]
@@ -49,19 +55,21 @@ This module relies on the following being true to keep things as simple as possi
 
 The following variables need to be passed to the module for it to work (we'll go through these in detail!):
 
-| Name                             | Type          | Description                                                                                                                           |
-|----------------------------------|---------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| `bucket_name`                    | `string`      | S3 bucket name                                                                                                                        |
-| `prefix_tables`                  | `map(string)` | A mapping from *prefix* to *table* name, giving the S3 prefix under which the data files will be auto-ingested into the table 'table' |
-| `database`                       | `string`      | Target database name                                                                                                                  |
-| `schema`                         | `string`      | Target schema name                                                                                                                    |
-| `file_format`                    | `string`      | Snowflake file format used for the files under each prefix. **All files _must_ share the same file format!**                          |
-| `storage_integration`            | `string`      | Snowflake storage integration's name                                                                                                  |
-| `storage_aws_iam_user_arn`       | `string`      | Snowflake storage integration's `STORAGE_AWS_IAM_USER_ARN` property                                                                   |
-| `storage_aws_external_id`        | `string`      | Snowflake storage integration's `STORAGE_AWS_EXTERNAL_ID` property                                                                    |
-| `snowflake_role_path`            | `string`      | AWS IAM path for the Snowflake role                                                                                                   |
-| `snowflake_role_name`            | `string`      | AWS IAM name for the Snowflake role                                                                                                   |
+| Name                             | Type               | Description                                                                                                                                                         |
+|----------------------------------|--------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `bucket_name`                    | `string`           | S3 bucket name                                                                                                                                                      |
+| `prefix_tables`                  | `map(map(string))` | A mapping from *table* to *table_name*, *prexix* and *copy_statement*, giving the S3 prefix under which the data files will be auto-ingested into the table 'table' |
+| `database`                       | `string`           | Target database name                                                                                                                                                |
+| `schema`                         | `string`           | Target schema name                                                                                                                                                  |
+| `file_format`                    | `string`           | Snowflake file format used for the files under each prefix. **All files _must_ share the same file format!**                                                        |
+| `storage_integration`            | `string`           | Snowflake storage integration's name                                                                                                                                |
+| `storage_aws_iam_user_arn`       | `string`           | Snowflake storage integration's `STORAGE_AWS_IAM_USER_ARN` property                                                                                                 |
+| `storage_aws_external_id`        | `string`           | Snowflake storage integration's `STORAGE_AWS_EXTERNAL_ID` property                                                                                                  |
+| `snowflake_role_path`            | `string`           | AWS IAM path for the Snowflake role                                                                                                                                 |
+| `snowflake_role_name`            | `string`           | AWS IAM name for the Snowflake role                                                                                                                                 |
 
+There is an example of how `prefix_tables` should look like as a `.yaml` file, that can be 
+then imported by the locals.
 
 ## Usage Steps
 
@@ -93,22 +101,26 @@ Having been created, you then need to:
 - Run `GRANT USAGE ON INTEGRATION <integration_name> TO ROLE <blah>;` in Snowflake, granting
   permissions to the role that will be creating the stage and the pipe
 
-### Step 3: Define the Prefix-Table mapping
+### Step 3: Load the Prefix-Table mapping
 
-We do this in a YAML file and load it into a variable with `yamldecode(file("prefix-tables.yaml")`
+We do this in a YAML file and load it into a variable with `yamldecode(file("pipes.yaml")`
 in Terraform. In fact, we just define a list of tables and define the mapping using:
 
 ```hcl
 locals {
-  tables         = yamldecode(file("tables.yaml"))
-  prefix_tables  = {
-    for table in local.tables : "${table}/" => table
-  }
+  tables         = yamldecode(file("pipes.yaml"))
 }
 ```
 
 As a result, we always load files from `{prefix}/` into `{table}`, so we don't have to remember
-which tables are loaded by which prefixes.
+which tables are loaded by which prefixes. It also provides an easy way to map each table with 
+their respective `copy_statements`.
+
+#### Parquet
+The default `file format` is `CSV`, but when we want to use `PARQUET` we need to pass a 
+bespoke `copy_statement` to the pipe. The reason for this is that `PARQUET` is interpreted as 
+a single column by Snowflake. As it is mention in the [documentation](https://docs.snowflake.com/en/user-guide/script-data-load-transform-parquet.html#sql-script-1-load-parquet-data).
+An example of a `PARQUET` copy statement has been provided in the `pipes.yaml` in the examples.
 
 ### Step 4: Rock and Roll
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ in Terraform. In fact, we just define a list of tables and define the mapping us
 
 ```hcl
 locals {
-  tables         = yamldecode(file("tables.yaml")
+  tables         = yamldecode(file("tables.yaml"))
   prefix_tables  = {
     for table in local.tables : "${table}/" => table
   }

--- a/examples/module_use
+++ b/examples/module_use
@@ -1,0 +1,23 @@
+locals {
+  pipes                 = yamldecode(file("pipes.yaml"))
+}
+
+module "snowflake-snowpipe" {
+  for_each                 = local.tables
+  source                   = "branchenergy/snowpipe/snowflake"
+  bucket_name              = "s3-bucket-name-${var.environment}"
+  prefix_tables            = local.pipes
+  database                 = "MY_DB"
+  schema                   = "SCHEMA"
+  file_format              = "PARQUET"
+  storage_integration      = var.storage_integration_name
+  storage_aws_iam_user_arn = aws_ssm_parameter.snowflake_external_account_arn.value
+  storage_aws_external_id  = aws_ssm_parameter.snowflake_external_id.value
+  snowflake_role_path      = var.snowflake_role_path
+  snowflake_role_name      = var.snowflake_role_name
+  snowflake_user           = var.snowflake_user
+  snowflake_account        = var.snowflake_account
+  snowflake_region         = var.snowflake_region
+  snowflake_private_key    = data.aws_secretsmanager_secret_version.snowflake_tf_private.secret_string
+}
+

--- a/examples/pipes.yaml
+++ b/examples/pipes.yaml
@@ -1,0 +1,31 @@
+table_identifier_1:
+  # Table identifier and table_name can be the same
+  name: table_name
+  # Prefix where the files are saved after inside the target s3 bucket. It can have multiple levels
+  prefix: prefix/
+  comment: Pipe description
+  # The copy statement is only necessary because we are using a .parquet format for our files
+  # %s and %[n]s will be populated with the database and schema automatically
+  copy_statement: >
+    copy into  %s.%s.my_table 
+    (
+        table_id,
+        col_varchar,
+        col_numeric,
+        col_timestamp
+    )
+    from 
+    (
+      select
+        $1:table_id::varchar,
+        $1:col_varchar::varchar,
+        $1:col_numeric::NUMBER(38,0),
+        $1:col_timestamp::varchar::TIMESTAMP_NTZ(9)
+      from @%[1]s.%[2]s.MY_STAGE
+    )
+
+table_identifier_2:
+  name: other_table_name
+  prefix: prefix/secondary
+  comment: Other pipe description
+  # NOTE: removing the copy_statement is not tested and might cause issues. In that case null can be passed

--- a/main.tf
+++ b/main.tf
@@ -18,10 +18,10 @@ terraform {
 
 locals {
   notification_inputs = {
-    for prefix, table in var.prefix_tables : prefix => {
-      id            = "Saving ${table} table inputs from ${prefix}"
-      topic_arn     = module.inner[prefix].topic_arn
-      filter_prefix = prefix
+    for table, values in var.prefix_tables : table => {
+      id            = "Saving ${table} table inputs from ${values["prefix"]}"
+      topic_arn     = module.inner[table].topic_arn
+      filter_prefix = values["prefix"]
     }
   }
 }
@@ -52,6 +52,18 @@ data "aws_iam_policy_document" "snowflake_integration" {
     resources = [
       data.aws_s3_bucket.this.arn
     ]
+  }
+
+  statement {
+    actions = [
+      "s3:DeleteObject",
+      "s3:PutObject"
+    ]
+
+    resources = [
+      "${data.aws_s3_bucket.this.arn}/*"
+    ]
+
   }
 }
 
@@ -94,18 +106,19 @@ resource "aws_iam_role_policy" "snowflake_integration" {
 
 
 module "inner" {
-  for_each                       = var.prefix_tables
-  source                         = "./modules/inner"
-  region                         = data.aws_s3_bucket.this.region
-  bucket_arn                     = data.aws_s3_bucket.this.arn
-  bucket_id                      = data.aws_s3_bucket.this.id
-  prefix                         = each.key
-  database                       = var.database
-  schema                         = var.schema
-  table_name                     = each.value
-  file_format                    = var.file_format
-  storage_integration            = var.storage_integration
-  storage_aws_iam_user_arn       = var.storage_aws_iam_user_arn
+  for_each                 = var.prefix_tables
+  source                   = "./modules/inner"
+  region                   = data.aws_s3_bucket.this.region
+  bucket_arn               = data.aws_s3_bucket.this.arn
+  bucket_id                = data.aws_s3_bucket.this.id
+  prefix                   = lookup(each.value, "prefix", null)
+  database                 = var.database
+  schema                   = var.schema
+  table_name               = lookup(each.value, "name", null)
+  file_format              = var.file_format
+  storage_integration      = var.storage_integration
+  storage_aws_iam_user_arn = var.storage_aws_iam_user_arn
+  pipe_copy_statement      = lookup(each.value, "copy_statement", null)
 }
 
 resource "aws_s3_bucket_notification" "this" {

--- a/modules/inner/main.tf
+++ b/modules/inner/main.tf
@@ -27,6 +27,8 @@ locals {
   pipe_name        = "PIPE_${upper(var.table_name)}"
   topic_name       = join("-", ["s3-snowpipe", replace(local.table_name_lower, "_", "-")])
   topic_arn        = "arn:aws:sns:${var.region}:${data.aws_caller_identity.current.account_id}:${local.topic_name}"
+  default_copy_statement = upper("copy into ${var.database}.${var.schema}.${var.table_name} from @${var.database}.${var.schema}.${local.stage_name}")
+  copy_statement         = var.pipe_copy_statement == null ? local.default_copy_statement : format(var.pipe_copy_statement, var.database, var.schema)
 }
 
 resource "aws_sns_topic" "this" {
@@ -131,7 +133,7 @@ resource "snowflake_pipe" "this" {
   name     = local.pipe_name
 
   comment           = "${var.table_name} pipe"
-  copy_statement    = upper("copy into ${var.database}.${var.schema}.${var.table_name} from @${var.database}.${var.schema}.${local.stage_name}")
+  copy_statement    = local.copy_statement
   auto_ingest       = true
   aws_sns_topic_arn = local.topic_arn
 

--- a/modules/inner/outputs.tf
+++ b/modules/inner/outputs.tf
@@ -1,3 +1,7 @@
 output "topic_arn" {
   value = aws_sns_topic.this.arn
 }
+
+output "snowflake_stage" {
+  value = snowflake_stage.this
+}

--- a/modules/inner/variables.tf
+++ b/modules/inner/variables.tf
@@ -47,3 +47,13 @@ variable "storage_aws_iam_user_arn" {
   type        = string
   description = "Snowflake storage integration's `STORAGE_AWS_IAM_USER_ARN` property"
 }
+
+variable "pipe_copy_statement"{
+  type        = string
+  default     = null
+  description = <<-EOT
+    Statement for copying data from the pipe into the table; by default
+
+    `COPY INTO [database].[schema].[table_name] from @[database].[schema].[stage_name]`
+  EOT
+}

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,7 @@ variable "bucket_name" {
 }
 
 variable "prefix_tables" {
-  type        = map(string)
+  type        = map(map(string))
   description = "A mapping from an S3 bucket prefix to the Snowflake table name into which it should be loaded"
 }
 
@@ -46,4 +46,30 @@ variable "snowflake_role_path" {
 variable "snowflake_role_name" {
   type        = string
   description = "Snowflake role name"
+}
+
+variable "snowflake_user" {
+  description = "Snoeflake's user name"
+}
+
+variable "snowflake_account" {
+  description = "Snoeflake's account"
+}
+
+variable "snowflake_region" {
+  description = "Region where your snowflake instance lives"
+}
+
+variable "snowflake_private_key" {
+  description = "Private key for snowflake"
+}
+
+variable "pipe_copy_statement"{
+  type        = string
+  default     = null
+  description = <<-EOT
+    Statement for copying data from the pipe into the table; by default
+
+    `COPY INTO [database].[schema].[table_name] from @[database].[schema].[stage_name]`
+  EOT
 }


### PR DESCRIPTION
Extending the functionality of the module to take a multi level map of attributes that can be used to customize each table type while maintaining the defaults. This is done by passing the attributes to the `inner` module and creating a `local.copy_statement` that will default if no statement is passed.

Modified README to incorporate the new functionality and make clearer the requirements to deploy the module. 
Added examples on how the `.yaml` file should look like as well as an example call to the module.